### PR TITLE
Removed copyright year.

### DIFF
--- a/_includes/page-footer.html
+++ b/_includes/page-footer.html
@@ -2,7 +2,7 @@
   <div class="usa-grid">
     <div class="usa-width-one-fourth">
       <img id="govt_logo" src="{{ site.baseurl }}/assets/img/footer-logo-govt.png" alt="NZ Government logo">
-      <p class="copyright">Crown Copyright 2019</p>
+      <p class="copyright">Crown Copyright</p>
     </div>
 
     <div class="usa-width-three-fourths creative-commons">


### PR DESCRIPTION
Removed copyright year as per Brenda's comment that it's not necessary for NZ Web content (see Trello).