### PR TITLE
Fixing the font for Expertise page.

### DIFF
--- a/_sass/_templates/how-we-work.scss
+++ b/_sass/_templates/how-we-work.scss
@@ -49,9 +49,7 @@
 }
 
 .expertise-subheading {
-  @include h3;
-  margin-bottom: 3rem;
-  margin-top: 0;
+  line-height: 1.5;
 }
 
 .expertise-main-content {


### PR DESCRIPTION
Fixing the font for Expertise page.

Somehow the font changed :/
It appears as this: 
![Bad](https://user-images.githubusercontent.com/13788498/62430247-164de500-b76e-11e9-8127-6d60b2781818.png)

But have fixed it in this PR to look normal:
![Correct](https://user-images.githubusercontent.com/13788498/62430251-22d23d80-b76e-11e9-8ed7-a4ff77f086b1.png)

