### PR TITLE
Global site tag for Google Analytics.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,15 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-KHXPF5R');</script>
 <!-- End Google Tag Manager -->
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-164758137-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-164758137-1');
+</script>
 
 <!-- Basic Page Needs
 ================================================== -->


### PR DESCRIPTION
Global site tag for Google Analytics.

Following instructions from: https://support.google.com/analytics/answer/1008080?hl=en-GB